### PR TITLE
Updated LLM model loading mechanism

### DIFF
--- a/chatify/chains.py
+++ b/chatify/chains.py
@@ -30,8 +30,25 @@ class CreateLLMChain:
 
         self.cache = config['cache_config']['cache']
         self.cacher = LLMCacher(config)
+
+        # Setup model and chain factory
+        self._setup_llm_model(config['model_config'])
         self._setup_chain_factory()
+
         return None
+
+    def _setup_llm_model(self, model_config):
+        """Sets up the LLM model.
+
+        Returns
+        --------
+        None
+        """
+        if self.llm_model is None:
+            self.llm_model = self.llm_models_factory.get_model(model_config)
+
+            if self.cache:
+                self.llm_model = self.cacher.cache_llm(self.llm_model)
 
     def _setup_chain_factory(self):
         """Sets up the chain factory dictionary.
@@ -58,7 +75,7 @@ class CreateLLMChain:
         )
         return PROMPT
 
-    def create_chain(self, model_config, prompt_template):
+    def create_chain(self, model_config=None, prompt_template=None):
         """Creates an LLM chain based on the model configuration and prompt template.
 
         Parameters
@@ -70,11 +87,6 @@ class CreateLLMChain:
         -------
         chain (LLMChain): LLM chain object.
         """
-        if self.llm_model is None:
-            self.llm_model = self.llm_models_factory.get_model(model_config)
-
-            if self.cache:
-                self.llm_model = self.cacher.cache_llm(self.llm_model)
 
         try:
             chain_type = self.chain_config['chain_type']

--- a/chatify/main.py
+++ b/chatify/main.py
@@ -13,7 +13,6 @@ from .chains import CreateLLMChain
 from .widgets import option_widget, button_widget, text_widget, thumbs
 
 from .utils import check_dev_config
-from .llm_models import HuggingFaceModel, LlamaModel
 
 
 @magics_class
@@ -38,7 +37,7 @@ class Chatify(Magics):
             # Check dev config file
             check_dev_config(self.cfg)
 
-        except FileNotFoundError: 
+        except FileNotFoundError:
             # If we don't find the user is an end-point user
             dirname = pathlib.Path(__file__).parent.resolve()
             self.cfg = yaml.load(
@@ -49,18 +48,6 @@ class Chatify(Magics):
         self.prompts_config = self.cfg["prompts_config"]
         self.llm_chain = CreateLLMChain(self.cfg)
         self.tabs = None
-
-        # download local model if needed
-        model_config = self.cfg["model_config"]
-        if model_config["model"] in ["huggingface_model", "llama_model"]:
-            print('Downloading and initializing model; this may take a few minutes...')
-
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                if model_config["model"] == "huggingface_model":
-                    llm = HuggingFaceModel(model_config).init_model()
-                elif model_config["model"] == "llama_model":
-                    llm = LlamaModel(model_config).init_model()            
 
     def _read_prompt_dir(self):
         """Reads prompt files from the dirname + '/prompts/' directory.


### PR DESCRIPTION
@jeremyforest, I changed the way LLM models are loaded in langchain. So, now model weights like (llama) are downloaded when we call `%load_ext chatify` not when we call `%%explain`. 